### PR TITLE
MySQLの接続を使い回す

### DIFF
--- a/torb/webapp/go/src/torb/app.go
+++ b/torb/webapp/go/src/torb/app.go
@@ -414,8 +414,8 @@ func main() {
 	var err error
 	db, err = sql.Open("mysql", dsn)
 	db.SetConnMaxLifetime(0)
-	db.SetMaxIdleConns(10000)
-	db.SetMaxOpenConns(10000)
+	db.SetMaxIdleConns(4000)
+	db.SetMaxOpenConns(4000)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/torb/webapp/go/src/torb/app.go
+++ b/torb/webapp/go/src/torb/app.go
@@ -413,6 +413,9 @@ func main() {
 
 	var err error
 	db, err = sql.Open("mysql", dsn)
+	db.SetConnMaxLifetime(0)
+	db.SetMaxIdleConns(10000)
+	db.SetMaxOpenConns(10000)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
デフォルトは使い終わったコネクションを捨ててしまうらしい

